### PR TITLE
Typo on calculateV60

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -50,7 +50,7 @@ function calculateV60_1C(element) {
     let coffeePerLiter = 60;
     let form = getFormElement(element);
 
-    liquidAndGroudns(form, element, coffeePerLiter);
+    liquidAndGrounds(form, element, coffeePerLiter);
 
     let amountLiquid = parseFloat(form.targetLiquid.value);
 


### PR DESCRIPTION
There is a typo when calling liquidAndGrounds() on the V60_1C section. This is breaking the calculation.